### PR TITLE
[FEATURE] S3 이미지 읽기 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
-# Unit test / coverage reports
+# Unit tests / coverage reports
 htmlcov/
 .tox/
 .nox/

--- a/app/api/endpoints/predictions.py
+++ b/app/api/endpoints/predictions.py
@@ -14,7 +14,7 @@ def get_redis_client(request: Request) -> redis.Redis:
 async def create_prediction_job(job_request: JobRequest, redis_client: redis.Redis = Depends(get_redis_client)):
     correlation_id = str(uuid.uuid4())
     job = ImageJob(
-        correlationId=correlationId,
+        correlationId=correlation_id,
         presignedUrl=job_request.presigned_url,
         replyQueue=settings.STREAM_RESULT,
         callbackUrl=None,

--- a/app/core/lifespan.py
+++ b/app/core/lifespan.py
@@ -1,7 +1,9 @@
 
 import asyncio
 from contextlib import asynccontextmanager
-import redis.asyncio as redis
+
+import anyio.to_thread
+import redis
 from fastapi import FastAPI
 
 from app.worker.redis_client import redis_client
@@ -10,19 +12,13 @@ from app.worker.worker import JobWorker
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    limiter = asyncio.to_thread.current_default_thread_limiter()
-    limiter.total_tokens = 50
+    limiter = anyio.to_thread.current_default_thread_limiter()
+    limiter.total_tokens = 100
 
-    try:
-        await redis_client.xgroup_create(
-            name=settings.STREAM_JOB,
-            groupname=settings.GROUP_NAME,
-            id="$",
-            mkstream=True
-        )
-    except redis.ResponseError as e:
-        if "BUSYGROUP" not in str(e):
-            raise
+    redis_client.xgroup_create(
+        stream_name=settings.STREAM_JOB,
+        group_name=settings.GROUP_NAME,
+    )
 
     worker = JobWorker(redis_client)
     worker_task = asyncio.create_task(worker.run())

--- a/app/core/lifespan.py
+++ b/app/core/lifespan.py
@@ -4,12 +4,14 @@ from contextlib import asynccontextmanager
 import redis.asyncio as redis
 from fastapi import FastAPI
 
+from app.worker.redis_client import redis_client
 from app.core.config import settings
 from app.worker.worker import JobWorker
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    redis_client = redis.from_url(settings.REDIS_URL, decode_responses=True)
+    limiter = asyncio.to_thread.current_default_thread_limiter()
+    limiter.total_tokens = 50
 
     try:
         await redis_client.xgroup_create(

--- a/app/services/predictor_service.py
+++ b/app/services/predictor_service.py
@@ -6,6 +6,7 @@ from torchvision import transforms
 from PIL import Image
 import json
 from pathlib import Path
+from io import BytesIO
 
 class LightCNN(nn.Module):
     def __init__(self, num_classes):
@@ -53,8 +54,8 @@ class PredictorService:
         model.eval()
         return model
 
-    def predict(self, image_path: Path) -> tuple[str, str, float]:
-        image = Image.open(image_path).convert('RGB')
+    async def predict(self, stream_file: BytesIO) -> tuple[str, str, float]:
+        image = Image.open(stream_file).convert('RGB')
         input_tensor = self.transform(image).unsqueeze(0).to(self.device)
 
         with torch.no_grad():

--- a/app/services/predictor_service.py
+++ b/app/services/predictor_service.py
@@ -54,7 +54,7 @@ class PredictorService:
         model.eval()
         return model
 
-    async def predict(self, stream_file: BytesIO) -> tuple[str, str, float]:
+    def predict(self, stream_file: BytesIO) -> tuple[str, str, float]:
         image = Image.open(stream_file).convert('RGB')
         input_tensor = self.transform(image).unsqueeze(0).to(self.device)
 

--- a/app/services/s3_service.py
+++ b/app/services/s3_service.py
@@ -1,8 +1,8 @@
 
 import boto3
 from botocore.config import Config as BotoConfig
-from pathlib import Path
 import requests
+from io import BytesIO
 
 from app.core.config import settings
 
@@ -18,10 +18,10 @@ class S3Service:
             ),
         )
 
-    def download_file_from_presigned_url(self, presigned_url: str, destination: Path):
+    def download_file_from_presigned_url(self, presigned_url: str) -> BytesIO:
         response = requests.get(presigned_url)
         response.raise_for_status()
-        with open(destination, "wb") as f:
-            f.write(response.content)
+
+        return BytesIO(response.content) # response 안의 content Stream으로 처리
 
 s3_service = S3Service()

--- a/app/worker/redis_client.py
+++ b/app/worker/redis_client.py
@@ -1,10 +1,95 @@
+import asyncio
 import redis
+
+from redis.asyncio import Redis as AsyncRedis
 from pydantic import BaseModel, Field
-from typing import Any, Dict
+from typing import Any, Dict, Optional, List
 from app.core.config import settings
 
-redis_client = redis.asyncio.from_url(settings.REDIS_URL, decode_responses=True)
-
+# Redis Stream Definition
 class PublishRequest(BaseModel):
-    stream: str = Field(default=settings.JOB_STREAM, description="Redis Stream Job name")
+    stream: str = Field(default=settings.STREAM_JOB, description="Redis Stream Job name")
     payload: Dict[str, Any]
+
+class RedisStreamClient:
+
+    def __init__(self):
+        self.redis_client = AsyncRedis.from_url(
+            url=settings.REDIS_URL,
+            decode_responses=True,
+        )
+
+    @classmethod
+    def init(cls):
+        broker = cls()
+        return broker
+
+    # Fast API 에서 Publish
+    async def xadd(self, stream_name: str, fields: Dict[str, Any]) -> str:
+        await self.redis_client.xadd(stream_name, fields)
+
+    # Group 단위로 읽어오기
+    async def xreadgroup(
+            self,
+            group_name: str,
+            consumer_name: str,
+            stream_name: str,
+            count: Optional[int] = None,
+            block: Optional[int] = None,
+            id: str = ">",
+    ) -> List[tuple]:
+        try:
+            # Create the consumer group ( 존재하지 않을 때 )
+            self.redis_client.xgroup_create(stream_name, group_name, id="$", mkstream=True)
+        except redis.exceptions.ResponseError as e:
+            # 이미 존재할 때
+            if "BUSYGROUP" not in str(e):
+                raise e
+
+        response = self.redis_client.xreadgroup(
+            groupname=group_name,
+            consumername=consumer_name,
+            streams={stream_name: id},
+            count=count,
+            block=block,
+        )
+        return response
+
+    # Consumer 처리 완료
+    def xack(self, stream_name: str, group_name: str, message_ids: List[str]) -> int:
+        return self.redis_client.xack(stream_name, group_name, *message_ids)
+
+    # 완료 시 삭제
+    def xack_and_del(self, stream_name: str, group_name: str, message_ids: List[str]) -> int:
+
+        acked_count = self.redis_client.xack(stream_name, group_name, *message_ids)
+
+        # XACK가 성공하면 스트림에서 해당 메시지를 삭제 (XDEL)
+        if acked_count > 0:
+            self.redis_client.xdel(stream_name, *message_ids)
+
+        return acked_count
+
+
+    # 메시지 재처리 지원
+    def xclaim(
+            self,
+            stream_name: str,
+            group_name: str,
+            consumer_name: str,
+            min_idle_time: int,
+            message_ids: List[str],
+    ) -> List[tuple]:
+
+        return self.redis_client.xclaim(
+            name=stream_name,
+            groupname=group_name,
+            consumername=consumer_name,
+            min_idle_time=min_idle_time,
+            message_ids=message_ids,
+        )
+
+    def close(self):
+        self.redis_client.disconnect()
+
+redis_client = RedisStreamClient.init()

--- a/app/worker/redis_client.py
+++ b/app/worker/redis_client.py
@@ -63,7 +63,7 @@ class RedisStreamClient:
         return await self.redis_client.xack(stream_name, group_name, *message_ids)
 
     # 완료 시 삭제
-    async def xack_and_del(self, stream_name: str, group_name: str, message_ids: List[str]) -> int:
+    async def xack_and_del(self, stream_name: str, group_name: str, message_ids: str) -> int:
 
         acked_count = await self.redis_client.xack(stream_name, group_name, *message_ids)
 

--- a/app/worker/redis_client.py
+++ b/app/worker/redis_client.py
@@ -26,7 +26,7 @@ class RedisStreamClient:
 
     # Fast API 에서 Publish
     async def xadd(self, stream_name: str, fields: Dict[str, Any]) -> str:
-        await self.redis_client.xadd(stream_name, fields)
+        return await self.redis_client.xadd(stream_name, fields)
 
     # Group 단위로 읽어오기
     async def xreadgroup(
@@ -35,44 +35,56 @@ class RedisStreamClient:
             consumer_name: str,
             stream_name: str,
             count: Optional[int] = None,
-            block: Optional[int] = None,
-            id: str = ">",
+            block: Optional[int] = None,  # ms 단위
+            id: str = ">",  # 새 메시지만 읽기
     ) -> List[tuple]:
         try:
-            # Create the consumer group ( 존재하지 않을 때 )
-            self.redis_client.xgroup_create(stream_name, group_name, id="$", mkstream=True)
+            # Create the consumer group (존재하지 않을 때)
+            self.redis_client.xgroup_create(
+                stream_name, group_name, id="$", mkstream=True
+            )
         except redis.exceptions.ResponseError as e:
             # 이미 존재할 때
             if "BUSYGROUP" not in str(e):
-                raise e
+                raise
 
-        response = self.redis_client.xreadgroup(
-            groupname=group_name,
-            consumername=consumer_name,
-            streams={stream_name: id},
+        streams = {stream_name: id}
+        response = await self.redis_client.xreadgroup(
+            group_name,  # groupname (positional)
+            consumer_name,  # consumername (positional)
+            streams,  # {stream: id} (positional)
             count=count,
             block=block,
         )
         return response
 
     # Consumer 처리 완료
-    def xack(self, stream_name: str, group_name: str, message_ids: List[str]) -> int:
-        return self.redis_client.xack(stream_name, group_name, *message_ids)
+    async def xack(self, stream_name: str, group_name: str, message_ids: List[str]) -> int:
+        return await self.redis_client.xack(stream_name, group_name, *message_ids)
 
     # 완료 시 삭제
-    def xack_and_del(self, stream_name: str, group_name: str, message_ids: List[str]) -> int:
+    async def xack_and_del(self, stream_name: str, group_name: str, message_ids: List[str]) -> int:
 
-        acked_count = self.redis_client.xack(stream_name, group_name, *message_ids)
+        acked_count = await self.redis_client.xack(stream_name, group_name, *message_ids)
 
         # XACK가 성공하면 스트림에서 해당 메시지를 삭제 (XDEL)
         if acked_count > 0:
-            self.redis_client.xdel(stream_name, *message_ids)
+            await self.redis_client.xdel(stream_name, *message_ids)
 
         return acked_count
 
+    async def xgroup_create(self, stream_name: str, group_name: str, id: str = "$") -> bool:
+        try:
+            self.redis_client.xgroup_create(stream_name, group_name, id, mkstream=True)
+            return True
+        except redis.exceptions.ResponseError as e:
+            if "BUSYGROUP" in str(e):
+                print(f"Consumer group '{group_name}' already exists.")
+                return False
+            raise e
 
     # 메시지 재처리 지원
-    def xclaim(
+    async def xclaim(
             self,
             stream_name: str,
             group_name: str,
@@ -81,15 +93,15 @@ class RedisStreamClient:
             message_ids: List[str],
     ) -> List[tuple]:
 
-        return self.redis_client.xclaim(
-            name=stream_name,
-            groupname=group_name,
-            consumername=consumer_name,
+        return await self.redis_client.xclaim(
+            stream_name=stream_name,
+            group_name=group_name,
+            consumer_name=consumer_name,
             min_idle_time=min_idle_time,
             message_ids=message_ids,
         )
 
-    def close(self):
-        self.redis_client.disconnect()
+    async def aclose(self):
+        await self.redis_client.close()
 
 redis_client = RedisStreamClient.init()

--- a/app/worker/tasks.py
+++ b/app/worker/tasks.py
@@ -1,7 +1,5 @@
 
 import asyncio
-import json
-from pathlib import Path
 import redis.asyncio as redis
 from datetime import datetime
 
@@ -13,13 +11,10 @@ from app.services.s3_service import s3_service
 async def process_image_scan(job: ImageJob, redis_client: redis.Redis):
     correlation_id = job.correlationId
     print(f"[task] Start image scan for job_id={correlation_id}")
-
-    temp_image_path = Path(f"/tmp/{correlation_id}.jpg")
-
     try:
-        s3_service.download_file_from_presigned_url(job.presignedUrl, temp_image_path)
+        stream_file = await asyncio.to_thread(s3_service.download_file_from_presigned_url(job.presignedUrl))
 
-        pill_name, label, confidence = predictor_service.predict(temp_image_path)
+        pill_name, label, confidence = await asyncio.to_thread(predictor_service.predict(stream_file))
 
         finished_at = datetime.utcnow().isoformat()
 
@@ -43,5 +38,4 @@ async def process_image_scan(job: ImageJob, redis_client: redis.Redis):
     except Exception as e:
         print(f"[task] Failed to process job_id={correlation_id}: {e}")
     finally:
-        if temp_image_path.exists():
-            temp_image_path.unlink()
+        print(f"[task] Image scan finished for job_id={correlation_id}")

--- a/app/worker/worker.py
+++ b/app/worker/worker.py
@@ -1,12 +1,12 @@
 
 import asyncio
-import redis.asyncio as redis
-from app.core.config import Settings
+from app.worker.redis_client import redis_client
+from app.core.config import settings
 from app.schemas.job import ImageJob
 from app.worker.tasks import process_image_scan
 
 class JobWorker:
-    def __init__(self, redis_client: redis.Redis):
+    def __init__(self, redis_client: redis_client):
         self.redis_client = redis_client
 
     async def run(self):
@@ -28,9 +28,15 @@ class JobWorker:
                     for msg_id, fields in entries:
                         try:
                             job = ImageJob.model_validate_json(fields["json"])
-                            await process_image_scan(job, redis_client)
-                            # 처리 성공 시에만 ack
-                            await redis_client.xack(settings.STREAM_JOB, settings.GROUP_NAME, msg_id)
+                            task = asyncio.create_task(process_image_scan(job, redis_client))
+                            print(f"[worker] {task} 발행 성공")
+                            # 처리 성공 시에만 ack 후 del
+                            task.add_done_callback(lambda t: asyncio.create_task(
+                                self.redis_client.xack_and_del(settings.STREAM_JOB, settings.GROUP_NAME, msg_id)
+                                if not t.exception() else
+                                self.redis_client.xadd(f"{settings.STREAM_JOB}:DLQ",
+                                                       {"id": msg_id, "error": str(t.exception()), **fields})
+                            ))
                         except asyncio.CancelledError:
                             # 취소되면 재전송되도록 ack 하지 않음
                             raise
@@ -54,8 +60,15 @@ class JobWorker:
                     for msg_id, fields in claimed:
                         try:
                             job = ImageJob.model_validate_json(fields["json"])
-                            asyncio.create_task(process_image_scan(job, self.redis_client))
-                            await self.redis_client.xack(settings.STREAM_JOB, settings.GROUP_NAME, msg_id)
+                            task = asyncio.create_task(process_image_scan(job, redis_client))
+                            print(f"[worker] {task} 발행 성공")
+                            # 처리 성공 시에만 ack 후 del
+                            task.add_done_callback(lambda t: asyncio.create_task(
+                                self.redis_client.xack_and_del(settings.STREAM_JOB, settings.GROUP_NAME, msg_id)
+                                if not t.exception() else
+                                self.redis_client.xadd(f"{settings.STREAM_JOB}:DLQ",
+                                                       {"id": msg_id, "error": str(t.exception()), **fields})
+                            ))
                         except Exception as e:
                             await self.redis_client.xadd(
                                 f"{settings.STREAM_JOB}:DLQ",

--- a/app/worker/worker.py
+++ b/app/worker/worker.py
@@ -17,9 +17,9 @@ class JobWorker:
         while True:
             try:
                 resp = await self.redis_client.xreadgroup(
-                    groupname=settings.GROUP_NAME,
-                    consumername=settings.CONSUMER_NAME,
-                    streams={settings.STREAM_JOB: ">"},
+                    group_name=settings.GROUP_NAME,
+                    consumer_name=settings.CONSUMER_NAME,
+                    stream_name={settings.STREAM_JOB: ">"},
                     count=10,
                     block=5000,
                 )

--- a/app/worker/worker.py
+++ b/app/worker/worker.py
@@ -19,7 +19,7 @@ class JobWorker:
                 resp = await self.redis_client.xreadgroup(
                     group_name=settings.GROUP_NAME,
                     consumer_name=settings.CONSUMER_NAME,
-                    stream_name={settings.STREAM_JOB: ">"},
+                    stream_name=settings.STREAM_JOB,
                     count=10,
                     block=5000,
                 )

--- a/tests/s3_service_test.py
+++ b/tests/s3_service_test.py
@@ -1,0 +1,39 @@
+import io
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.services.s3_service import s3_service
+
+class TestDownloadFile:
+    @patch("app.services.s3_service.requests.get")
+    def test_download_file_success(self, mock_get):
+        # arrange
+        mock_get.return_value = MagicMock()
+        mock_get.return_value.content = b"test file content"
+        mock_get.return_value.raise_for_status = MagicMock()
+
+        # act
+        obj = s3_service
+        result = obj.download_file_from_presigned_url(
+            "http://fake-url.com"
+        )
+
+        # assert
+        assert isinstance(result, io.BytesIO)
+        assert result.getvalue() == b"test file content"
+        mock_get.assert_called_once_with(
+            "http://fake-url.com"
+        )
+        mock_get.return_value.raise_for_status.assert_called_once()
+
+    @patch("app.services.s3_service.requests.get")
+    def test_download_file_http_error(self, mock_get):
+        # arrange
+        mock_get.return_value = MagicMock()
+        mock_get.return_value.raise_for_status.side_effect = Exception("HTTP Error")
+
+        obj = s3_service
+
+        # act & assert
+        with pytest.raises(Exception, match="HTTP Error"):
+            obj.download_file_from_presigned_url("http://fake-url.com")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app=app)
+
+def test_health_check():
+    response = client.get("/api/v1/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## 📌 작업 목적
- S3의 로직에 대한 테스트를 실시
- Redis를 비동기 기반으로 전환

---

## 🗂 작업 유형
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [x] 리팩터링 (Refactor)
- [x] 테스트 추가/수정 (Test)

---

## 🔨 주요 작업 내용
- S3로 다운 받은 이미지에 대하여 Path로 따로 저장을 거치던 것을 수정하였습니다.
** `s3_service.py` **
```python
    def download_file_from_presigned_url(self, presigned_url: str) -> BytesIO:
        response = requests.get(presigned_url)
        response.raise_for_status()
```
   - presignedUrl을 받으면 get method를 통하여 Byte 파일로 입력 후 전달
   - 이 반환을 `predict`가 사용하게 됨

<br>

- s3_service에 대한 테스트 코드 작성
```python
@patch("app.services.s3_service.requests.get")
    def test_download_file_success(self, mock_get):
        # arrange
        mock_get.return_value = MagicMock()
        mock_get.return_value.content = b"test file content"
        mock_get.return_value.raise_for_status = MagicMock()
```

    - 해당 경로의 서비스에서의 request.get 함수를 mock 객체 대상으로 선정 ( requests.get() → mock_get() → MagicMock() 객체 반환. )
    - 최종적으로 메모리 기반 바이너리 스트림인지에 대한 테스트
    
<br>

- Redis Stream에 대한 작업을 비동기로 구현하여 redis_client라는 공통된 클래스를 사용하도록 설정하였습니다.

```python
class RedisStreamClient:

    def __init__(self):
        self.redis_client = AsyncRedis.from_url(
            url=settings.REDIS_URL,
            decode_responses=True,
        )
```

    - `async def` 키워드로 코루틴을 정의하고 이를 통해 비동기 작업을 수행합니다
    - `await` 키워드를 사용하여 해당 비동기 작업이 완료 때까지 실행을 일시 중단 -> 그 동안 이벤트 루프가 다른 작업을 처리할 수 있도록 함

<br>

- XACK 후의 XDEL 처리로 완료된 작업에 대하여는 더이상 스트림에 유지되지 않도록 설정
```
async def xack_and_del(self, stream_name: str, group_name: str, message_ids: List[str]) -> int:
```

<br>

- `lifespan.py` 에서 설정한 비동기 컨텍스트 설정
```python
@asynccontextmanager
async def lifespan(app: FastAPI):
    limiter = anyio.to_thread.current_default_thread_limiter()
    limiter.total_tokens = 100
```
    - anyio.to_thread 를 통하여 동시 설정 가능한 스레드의 수를 우선 100으로 설정

---
## 📎 관련 이슈
- Closes #5 

---

## 💬 논의 및 고민한 점
- 사실 로직의 흐름이 PresignedURL이므로, S3 설정을 추가하지 않아도 되어 다음 이슈 때 삭제하겠습니다.
- TTL을 Spring에 맞춰 설정하여 타임 안에 처리하지 못한 작업은 삭제하는 후처리를 하겠습니다.
- Task 부분 상세 작업 필요 (dict 타입 문제 발생 )

---
